### PR TITLE
Deploy Docker Application on Port 8080

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Docker Instance/Container 
         run: |
           sudo docker run -d \
-          -p 80:8080 \
+          -p 8080:8080 \
           --restart unless-stopped \
           --env-file /home/ec2-user/.env \
           --name pantrypal-cd-pipeline-container \


### PR DESCRIPTION
Refactor GIthub Actions to deploy on Port 8080 because nginx is using Port 80 and 443 for HTTP and HTTPS.